### PR TITLE
Spec: add publishIntake command (future support)

### DIFF
--- a/api/packet.json
+++ b/api/packet.json
@@ -44,6 +44,15 @@
         "MAC": "AA:BB:CC:00:11:22",
         "session": "0123456789abcdef"
     },
+    "publishIntake": {
+        "__status__": "FUTURE-SUPPORT",
+        "MAC": "AA:BB:CC:00:11:22",
+        "id": "0123456789abcdef",
+        "barcode": "0123456789abcdef",
+        "weight": "297.00",
+        "session": "0123456789abcdef",
+        "transactionId": "6f9c2e2c-1b7a-4f0e-9a1a-2c9d4e5f6a7b"
+    },
     "publishScaleWeight": {
         "MAC": "AA:BB:CC:00:11:22",
         "id": "0123456789abcdef",

--- a/api/robot-api.md
+++ b/api/robot-api.md
@@ -461,6 +461,32 @@ what settles which release a terminal is on is the `rootfs` field in its next
 }
 ```
 
+#### Publish an Intake Tip - INTAKE PROFILE - FUTURE SUPPORT
+> **Future support.** Not yet implemented on the server or firmware. Reserved here as part of the spec.
+
+Records a single tip of fruit at the infeed (a bin tipper or pre-sort line). Sent once per tip by a terminal configured with the `INTAKE` profile. The terminal never names a run - the server feeds whatever run is open on the terminal's line.
+
+Everything except `MAC` is optional, so the same command serves a line that scans the bin, one that weighs it, and one that only counts:
+- `id` - the operator's key card, resolved as in `publishLogon`.
+- `barcode` - the bin's SSCC/id. Omitted on a count-only line.
+- `weight` - mass tipped in kg. Omitted where the line does not weigh; the bin's known mass then stands.
+- `transactionId` - a UUID for the tip so a retry over a flaky link is not double-counted; the server replays the first answer for a repeated id.
+
+```JSON
+{
+    "publishIntake" : {
+        "MAC" : "AA:BB:CC:00:11:22",
+        "id" : "0123456789abcdef",
+        "barcode" : "0123456789abcdef",
+        "weight" : "297.00",
+        "session" : "0123456789abcdef",
+        "transactionId" : "6f9c2e2c-1b7a-4f0e-9a1a-2c9d4e5f6a7b"
+    }
+}
+```
+
+The response is a standard `responseStation`: on a tip, green with the run's running tip count and mass on `LCD4`; on a refusal (unknown or empty bin, no open run, run closed, bad weight) orange/red with the reason, and the tip is not counted.
+
 #### Move a Pallet - FORKLIFT PROFILE
 To move a pallet two commands are needed. First is to request the move, which verifies the pallet location. The second is to publish the new position.
 


### PR DESCRIPTION
Adds the `publishIntake` command to the ROBOT-API spec, in the `api/` docs, **marked as future support** (not yet implemented on server or firmware).

`publishIntake` records **one tip of fruit at the infeed** for a terminal on the `INTAKE` profile (bin tipper / pre-sort). The terminal never names a run — the server feeds whatever run is open on its line.

**Changes**
- `api/robot-api.md` — new "Publish an Intake Tip — INTAKE PROFILE — FUTURE SUPPORT" section under Publish Transactions: request fields (`MAC`, `id` card, optional `barcode`/`weight`, `session`, `transactionId` for idempotency) and the standard `responseStation` reply.
- `api/packet.json` — sample packet, tagged `"__status__": "FUTURE-SUPPORT"`.

Firmware tracking issues: RadicalES/robot-t201-http#2, RadicalES/robot-t202-fw#7.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018aBkMyNHkx2n96sEAUyRGU